### PR TITLE
Fix automatic deploy from master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm run build
 ```bash
 npm run deploy
 ```
+Las builds se compilan y despliegan de forma automática al hacer push a la rama `master` gracias al workflow de GitHub Actions, por lo que no es necesario ejecutar el comando anterior a menos que quieras hacerlo manualmente.
 📄 Licencia
 
 Este proyecto está bajo una licencia abierta. Puedes usarlo y modificarlo libremente, siempre que me menciones como autor original.


### PR DESCRIPTION
## Summary
- adjust workflow to trigger only on master branch
- clarify automatic deployment in README

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853cd0c0b98832789f4097dca6e9a67