### PR TITLE
Fix language popover closing and mobile spacing

### DIFF
--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -249,7 +249,7 @@
     padding: 0;
     text-align: center; /* Centrar en móvil */
     width: 100%; /* Ancho completo */
-    margin-bottom: 3rem; /* Aumentado el espacio entre links y selector de idioma */
+    margin-bottom: 1.5rem; /* Menor espacio entre links y selector de idioma */
 }
   
 .mobile-nav-links li {
@@ -278,8 +278,8 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 2rem; /* Espacio entre selector de idioma y botón de tema */
+    margin-top: 0;
+    margin-bottom: 1rem; /* Espacio más reducido */
 }
   
 /* 🔹 Cambio de tema en móvil */

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -13,6 +13,8 @@ const NavBar = () => {
   const [showMenu, setShowMenu] = useState(window.innerWidth <= 768);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false); // Estado para animar el cierre
+  const [languageOpen, setLanguageOpen] = useState(false);
+  const [languageOpenMobile, setLanguageOpenMobile] = useState(false);
 
   const t = locales[language];
 
@@ -89,16 +91,16 @@ const NavBar = () => {
                 <li><a href="" onClick={(e) => scrollToSection(e, "contacto")}>{t.contacto}</a></li>
               </ul>
 
-              <Popover>
+              <Popover open={languageOpen} onOpenChange={setLanguageOpen}>
                 <PopoverTrigger asChild>
                   <Button variant="ghost" className="language-button">
                     {language.toUpperCase()} ▼
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className={`language-dropdown ${theme}`}>
-                  <button onClick={() => setLanguage("es")}>Español</button>
-                  <button onClick={() => setLanguage("en")}>English</button>
-                  <button onClick={() => setLanguage("ca")}>Català/Valencià</button>
+                  <button onClick={() => { setLanguage("es"); setLanguageOpen(false); }}>Español</button>
+                  <button onClick={() => { setLanguage("en"); setLanguageOpen(false); }}>English</button>
+                  <button onClick={() => { setLanguage("ca"); setLanguageOpen(false); }}>Català/Valencià</button>
                 </PopoverContent>
               </Popover>
 
@@ -120,16 +122,16 @@ const NavBar = () => {
           <li><a onClick={(e) => scrollToSection(e, "contacto")}>{t.contacto}</a></li>
         </ul>
 
-        <Popover>
+        <Popover open={languageOpenMobile} onOpenChange={setLanguageOpenMobile}>
           <PopoverTrigger asChild>
             <Button variant="ghost" className="language-button">
               <GlobeIcon size={20} /> {language.toUpperCase()} ▼
             </Button>
           </PopoverTrigger>
           <PopoverContent className="language-dropdown-mobile">
-            <button onClick={() => setLanguage("es")}>Español</button>
-            <button onClick={() => setLanguage("en")}>English</button>
-            <button onClick={() => setLanguage("ca")}>Català/Valencià</button>
+            <button onClick={() => { setLanguage("es"); setLanguageOpenMobile(false); }}>Español</button>
+            <button onClick={() => { setLanguage("en"); setLanguageOpenMobile(false); }}>English</button>
+            <button onClick={() => { setLanguage("ca"); setLanguageOpenMobile(false); }}>Català/Valencià</button>
           </PopoverContent>
         </Popover>
 


### PR DESCRIPTION
## Summary
- close language selector after choosing an option
- manage open state for mobile and desktop language menus
- tighten spacing in mobile nav menu

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations for React and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_6853e76d9f308327a7e70c37e5a16f06