### PR TITLE
Fix language selector overlapping theme icon on mobile

### DIFF
--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -291,6 +291,12 @@
     transition: transform 0.2s ease;
     margin-top: 1.5rem; /* Más espacio arriba */
     margin-bottom: 1rem; /* Espacio abajo */
+    position: relative; /* Crear contexto de apilamiento */
+    z-index: 900; /* Debajo del desplegable de idioma */
+}
+
+.mobile-theme-hidden {
+    display: none;
 }
   
 .mobile-theme svg {
@@ -302,7 +308,7 @@
 }
   
 .language-dropdown-mobile {
-    z-index: 1100 !important;
+    z-index: 1200 !important;
     position: absolute !important;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
     padding: 0.5rem !important;

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { SunIcon, MoonIcon, GlobeIcon, MenuIcon, XIcon } from "lucide-react";
 import { useTheme } from "@/context/ThemeContext";
 import { useLanguage } from "@/context/LanguageContext";
@@ -135,7 +136,13 @@ const NavBar = () => {
           </PopoverContent>
         </Popover>
 
-        <Button onClick={toggleTheme} className="mobile-theme">
+        <Button
+          onClick={toggleTheme}
+          className={cn(
+            "mobile-theme",
+            languageOpenMobile && "mobile-theme-hidden"
+          )}
+        >
           {theme === "light" ? <MoonIcon /> : <SunIcon color="white" />}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- import cn utility in NavBar
- hide the mobile theme icon while the language dropdown is open

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ea37ffe883279da803298e9aa089